### PR TITLE
Fix encoding for event titles

### DIFF
--- a/steameventparser.php
+++ b/steameventparser.php
@@ -33,7 +33,7 @@ class SteamEventParser {
 	 */
 	private function parseEvent($str, $month, $year, $tzSrc, $tzDest) {
 		$html = new DOMDocument();
-		$html->loadHTML($str);
+		$html->loadHTML("<?xml encoding='UTF-8' ?>" . $str);
 		$event = array();
 		$node = $html->getElementsByTagName("body");
 		foreach ($node as $body) {


### PR DESCRIPTION
I didn't find a good way to set the encoding for DOMDocument::loadHTML(), and wrapping $str in a proper `<html><head><meta charset=…></head><body>…</body></html>` broke things - feel free to reject if you know a better way.

I think it's ok to hardcode UTF-8 here though as if I interpret the note on http://php.net/manual/en/class.domnode.php correctly the `$e->nodeValue` passed to parseEvent() should already be decoded to UTF-8.