### PR TITLE
Limit the number of cookies we serve

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -36,6 +36,9 @@ if ( !isset($skipAuth) ) {
 			exit();
 		} else {
 
+			// If we had a session cookie, we can now eat it :>
+			sec_session_destroy();
+
 			$steam_sign_in_url = SteamSignIn::genUrl();
 			$logIn = <<<AUTHBUTTON
 <li class="steamLogin"><a href="{$steam_sign_in_url}"><img src="/images/sits_large_noborder.png" alt="Log into Steam" /></a></li>

--- a/includes/session.php
+++ b/includes/session.php
@@ -16,8 +16,23 @@
 		session_regenerate_id(true); // regenerated the session, delete the old one
 	}
 
+	function sec_session_destroy() {
+		session_destroy();
+		// Remove the client's session cookie as well by expiring it
+		setcookie(
+			ini_get("session.name"),
+			"",
+			time() - 3600,
+			"/",
+			"",
+			ini_get("session.cookie_secure"),
+			ini_get("session.cookie_httponly")
+		);
+	}
+
 	function login($uid)
 	{
+		sec_session_start();
 		$_SESSION['u'] = $uid;
 		$_SESSION['g'] = group_check($uid);
 		store_user_details($uid);
@@ -28,7 +43,7 @@
 
 	function logout()
 	{
-		session_destroy();
+		sec_session_destroy();
 		header ("Location: /");
 	}
 
@@ -93,5 +108,8 @@
 		return;
 	}
 
-	sec_session_start();
+	// Only start/resume a session if we potentially have one
+	if (isset($_COOKIE[ini_get("session.name")])) {
+		sec_session_start();
+	}
 

--- a/includes/session.php
+++ b/includes/session.php
@@ -28,6 +28,9 @@
 			ini_get("session.cookie_secure"),
 			ini_get("session.cookie_httponly")
 		);
+		foreach ($_SESSION as $k => $v) {
+			unset($_SESSION[$k]);
+		}
 	}
 
 	function login($uid)

--- a/includes/session.php
+++ b/includes/session.php
@@ -17,19 +17,23 @@
 	}
 
 	function sec_session_destroy() {
-		session_destroy();
-		// Remove the client's session cookie as well by expiring it
-		setcookie(
-			ini_get("session.name"),
-			"",
-			time() - 3600,
-			"/",
-			"",
-			ini_get("session.cookie_secure"),
-			ini_get("session.cookie_httponly")
-		);
-		foreach ($_SESSION as $k => $v) {
-			unset($_SESSION[$k]);
+		if (isset($_SESSION)) {
+			session_destroy();
+			unset($_SESSION);
+		}
+		$n = ini_get("session.name");
+		if (isset($_COOKIE[$n])) {
+			// Remove the client's session cookie as well by expiring it
+			setcookie(
+				$n,
+				"",
+				time() - 3600,
+				"/",
+				"",
+				ini_get("session.cookie_secure"),
+				ini_get("session.cookie_httponly")
+			);
+			unset($_COOKIE[$n]);
 		}
 	}
 


### PR DESCRIPTION
Currently we're serving a bunch of session cookies to anyone who visits the site, even if they aren't yet logged in or have no intention of logging in. From a privacy standpoint it would probably be a good idea to not allow ourselves to even have the ability of doing too much tracking on these users. Could someone take a look at this/give this a whirl on staging?